### PR TITLE
Templates for simple Resources Test infrastructure

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -165,12 +165,14 @@ var serverGenerator = generators.Base.extend({
         this.databaseName       = answers.databaseName;
         this.routers            = answers.routers || [];
         this.schemas            = answers.schemas || [];
+        this.resources          = answers.resources || [];
 
-        if (answers.resources) {
-          answers.resources.forEach((resouceName) => {
-            this.routers.push(resouceName);
-            this.schemas.push(resouceName);
+        if (this.resources) {
+          this.resources.forEach((resourceName) => {
+            this.routers.push(resourceName);
+            this.schemas.push(resourceName);
           });
+          this.resources = this.resources.map(genResourceNames);
         }
 
         this.routers = this.routers.map(genResourceNames);
@@ -288,8 +290,17 @@ var serverGenerator = generators.Base.extend({
     main: function() {
       this.fs.copyTpl(
         this.templatePath('lib/main.js'),
-        this.destinationPath('lib/' + this.serverName + '.js'),
+        this.destinationPath(`lib/${ this.serverName }.js`),
         { serverClassName: this.serverClassName }
+      );
+      this.fs.copyTpl(
+        this.templatePath('test/lib.main-d.spec.js'),
+        this.destinationPath(`test/lib.${ this.serverName }-d.spec.js`),
+        {
+          serverClassName: this.serverClassName,
+          serverInstanceName: this.serverInstanceName,
+          name: this.serverName
+        }
       );
     },
 
@@ -351,6 +362,49 @@ var serverGenerator = generators.Base.extend({
           _this.destinationPath('schema/' + schema.name + '.js'),
           schema
         );
+      });
+    },
+
+    resourceTests: function() {
+      let _this = this;
+      const otherFixtures = [ 'new', 'update' ];
+      const paths = [
+        'test/lib/assert-contains.js',
+        'test/lib.database.spec.js',
+        'test/mock/logger.js'
+      ];
+
+      paths.forEach( (path) => {
+        _this.fs.copy(
+          _this.templatePath(path),
+          _this.destinationPath(path)
+        );
+      });
+
+      _this.resources.forEach( (resource) => {
+        const templateArgs = {
+          instanceName: resource.instanceName,
+          className: resource.className,
+          name: resource.name,
+          serverInstanceName: _this.serverInstanceName
+        };
+        _this.fs.copyTpl(
+          _this.templatePath('test/route.spec.js'),
+          _this.destinationPath(`test/route.${ resource.name }.spec.js`),
+          templateArgs
+        );
+        _this.fs.copyTpl(
+          _this.templatePath('test/fixture/instance.js'),
+          _this.destinationPath(`test/fixture/${ resource.name }-1.js`),
+          templateArgs
+        );
+        otherFixtures.forEach( (fixture) => {
+          _this.fs.copyTpl(
+            _this.templatePath(`test/fixture/${fixture}.js`),
+            _this.destinationPath(`test/fixture/${fixture}-${ resource.name }-1.js`),
+            templateArgs
+          );
+        });
       });
     }
   },

--- a/generators/app/templates/schema.js
+++ b/generators/app/templates/schema.js
@@ -3,7 +3,7 @@ const mongooseSlugs = require('../lib/mongoose-slugs');
 
 
 const <%= instanceName %>Schema = new Schema({
-  title: { type: String },
+  title: { type: String, required: true },
   body:  { type: String }
 });
 

--- a/generators/app/templates/test/fixture/instance.js
+++ b/generators/app/templates/test/fixture/instance.js
@@ -1,0 +1,11 @@
+const ObjectId = require('mongodb').ObjectId;
+
+
+const <%= className %>1 = {
+  _id: new ObjectId('12a3d077c143c921072e342a'),
+  title: 'Title',
+  body: 'Body'
+};
+
+
+module.exports = <%= className %>1;

--- a/generators/app/templates/test/fixture/new.js
+++ b/generators/app/templates/test/fixture/new.js
@@ -1,0 +1,7 @@
+const new<%= className %>1 = {
+  title: 'Title',
+  body: 'Body'
+};
+
+
+module.exports = new<%= className %>1;

--- a/generators/app/templates/test/fixture/update.js
+++ b/generators/app/templates/test/fixture/update.js
@@ -1,0 +1,11 @@
+const ObjectId = require('mongodb').ObjectId;
+
+
+const update<%= className %>1 = {
+  _id: new ObjectId('12a3d077c143c921072e342a'),
+  title: 'Foo',
+  body: 'Body'
+};
+
+
+module.exports = update<%= className %>1;

--- a/generators/app/templates/test/lib.database.spec.js
+++ b/generators/app/templates/test/lib.database.spec.js
@@ -1,0 +1,121 @@
+/* eslint-disable max-len */
+/* global describe it */
+
+const sinon                = require('sinon');
+const assert               = require('assert');
+const Mongoose             = require('mongoose').Mongoose;
+const mongooseTimestamp    = require('mongoose-cu-timestamps');
+const mongooseSoftRemove   = require('mongoose-soft-remove');
+const mongooseCountAndFind = require('mongoose-count-and-find');
+
+// NOTE: Fix for sinon ClockDate
+const Types = Mongoose.prototype.Schema.Types;
+Types.ClockDate = Types.Date;
+
+const logger = require('./mock/logger.js');
+const Database = require('../lib/database');
+
+
+describe('new Database(config, logger) -> database', () => {
+  it('exposes the config and logger as properties', () => {
+    const config = {};
+    const database = new Database(config, logger);
+
+    assert.equal(database.config, config);
+    assert.equal(database.logger, logger);
+  });
+
+  it('creates an instance of mongoose and exposes it as a property', () => {
+    const database = new Database({}, logger);
+    assert.ok(database.mongoose instanceof Mongoose);
+  });
+
+  it('loads required global mongoose plugins', () => {
+    const database = new Database({}, logger);
+
+    const requiredPlugins = [
+      mongooseTimestamp,
+      mongooseSoftRemove,
+      mongooseCountAndFind
+    ];
+
+    for (let i = 0; i < requiredPlugins.length; i += 1) {
+      let isLoaded = false;
+      for (let j = 0; j < database.mongoose.plugins.length; j += 1) {
+        if (database.mongoose.plugins[j][0] === requiredPlugins[i]) {
+          isLoaded = true;
+          break;
+        }
+      }
+      assert.ok(isLoaded);
+    }
+  });
+
+  describe('#connect(cb(err))', () => {
+
+    it('calls connect on the internal mongoose instance', sinon.test(() => {
+      const config   = { mongo: { url: 'MONGO_URL' } };
+      const database = new Database(config, logger);
+      sinon.stub(database.mongoose, 'connect').callsArgWith(1, null);
+      const cbStub = sinon.stub();
+
+      database.connect(cbStub);
+
+      sinon.assert.calledOnce(database.mongoose.connect);
+      sinon.assert.calledWith(database.mongoose.connect, config.mongo.url);
+      sinon.assert.calledOnce(cbStub);
+    }));
+  });
+
+
+  describe('#disconnect(cb(err))', () => {
+
+    it('calls disconnect on the internal mongoose instance', sinon.test(() => {
+      const database = new Database({}, logger);
+      sinon.stub(database.mongoose, 'disconnect').callsArgWith(0, null);
+      const cbStub = sinon.stub();
+
+      database.disconnect(cbStub);
+
+      sinon.assert.calledOnce(database.mongoose.disconnect);
+      sinon.assert.calledOnce(cbStub);
+    }));
+  });
+
+
+  describe('#model(modelName, [schema]) -> Model', () => {
+
+    it('is an alias to mongoose.model', sinon.test(() => {
+      const database = new Database({}, logger);
+      sinon.stub(database.mongoose, 'model').returns('MODEL');
+
+      database.model(1, 2, 3, 4, 5, 6, 7, 8);
+
+      sinon.assert.calledOnce(database.mongoose.model);
+      sinon.assert.calledWith(database.mongoose.model, 1, 2, 3, 4, 5, 6, 7, 8);
+    }));
+  });
+
+
+  describe('#ping(cb)', () => {
+
+    it('is an alias to mongoose.model', sinon.test(() => {
+      const database     = new Database({}, logger);
+      const adminApiStub = {
+        ping: sinon.stub().callsArgWith(0, null, 'RESULT')
+      };
+      database.mongoose.connection.db = {
+        admin: () => adminApiStub
+      };
+      const stubCb = sinon.stub();
+
+      database.ping(stubCb);
+
+      sinon.assert.calledOnce(adminApiStub.ping);
+      sinon.assert.calledOnce(stubCb);
+      sinon.assert.calledWith(stubCb, null, 'RESULT');
+
+      delete database.mongoose.connection.db;
+    }));
+  });
+});

--- a/generators/app/templates/test/lib.main-d.spec.js
+++ b/generators/app/templates/test/lib.main-d.spec.js
@@ -1,0 +1,58 @@
+/* eslint-disable max-len */
+/* global describe it */
+
+const assert = require('assert');
+const sinon = require('sinon');
+const <%= serverClassName %> = require('../lib/<%= name %>');
+const logger = require('./mock/logger');
+
+describe('new <%= serverClassName %>(config, logger) -> <%= serverInstanceName %>', () => {
+  describe('#start(cb(err))', () => {
+    it('starts the database and server', sinon.test((cb) => {
+      const config = {
+        consul: { url: 'http://localhost:8001' },
+        vault: {},
+        server: { url: 'http://localhost:8000' } };
+      const <%= serverInstanceName %> = new <%= serverClassName %>(config, logger);
+
+      sinon.stub(<%= serverInstanceName %>.database, 'connect').callsArgWith(0, null);
+      sinon.stub(<%= serverInstanceName %>.server, 'listen').callsArgWith(0, null);
+      sinon.stub(<%= serverInstanceName %>.tribune, 'register').callsArgWith(2, null);
+
+      <%= serverInstanceName %>.start((err, result) => {
+        if (err) { return cb(err); }
+
+        sinon.assert.calledOnce(<%= serverInstanceName %>.database.connect);
+        sinon.assert.calledOnce(<%= serverInstanceName %>.server.listen);
+        sinon.assert.calledOnce(<%= serverInstanceName %>.tribune.register);
+
+        assert.deepEqual(result, { url: 'http://localhost:8000' });
+
+        cb(null);
+      });
+    }));
+  });
+
+  describe('#stop(cb(err))', () => {
+    it('starts the database and server', sinon.test((cb) => {
+      const config = { consul: { url: 'http://localhost:8001' } };
+      const <%= serverInstanceName %> = new <%= serverClassName %>(config, logger);
+
+      <%= serverInstanceName %>.isRunning = true;
+
+      sinon.stub(<%= serverInstanceName %>.database, 'disconnect').callsArgWith(0, null);
+      sinon.stub(<%= serverInstanceName %>.server, 'close').callsArgWith(0, null);
+      sinon.stub(<%= serverInstanceName %>.tribune, 'deregister').callsArgWith(0, null);
+
+      <%= serverInstanceName %>.stop((err) => {
+        if (err) { return cb(err); }
+
+        sinon.assert.calledOnce(<%= serverInstanceName %>.database.disconnect);
+        sinon.assert.calledOnce(<%= serverInstanceName %>.server.close);
+        sinon.assert.calledOnce(<%= serverInstanceName %>.tribune.deregister);
+
+        cb(null);
+      });
+    }));
+  });
+});

--- a/generators/app/templates/test/lib/assert-contains.js
+++ b/generators/app/templates/test/lib/assert-contains.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+
+
+const isObject = (obj) => obj && typeof obj === 'object';
+
+const trimObject = (obj, pattern) => {
+  if (!isObject(obj) || !isObject(pattern)) {
+    return;
+  }
+
+  for (const prop in obj) {
+    if (isObject(obj[prop]) && isObject(pattern[prop])) {
+      trimObject(obj[prop], pattern[prop]);
+      continue;
+    }
+
+    if (pattern[prop] === undefined) {
+      delete obj[prop];
+    }
+  }
+};
+
+const fail = (obj, pattern, message) => {
+  trimObject(obj, pattern);
+  assert.fail(obj, pattern, message, '∈', assertContains); // eslint-disable-line
+};
+
+const contains = (obj, pattern) => {
+  if (!isObject(obj) || !isObject(pattern)) {
+    return obj === pattern;
+  }
+
+  if (typeof obj.length === 'number' && typeof pattern.length === 'number') {
+    for (let i = 0; i < pattern.length; i += 1) {
+      let isPresent = false;
+      for (let j = 0; j < obj.length; j += 1) {
+        if (contains(obj[j], pattern[i])) {
+          isPresent = true;
+          break;
+        }
+      }
+      if (!isPresent) { return false; }
+    }
+    return true;
+  }
+
+  for (const prop in pattern) {
+    if (pattern[prop] !== undefined && !contains(obj[prop], pattern[prop])) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const assertContains = (obj, pattern, message) => {
+  if (!isObject(obj) || !isObject(pattern)) {
+    throw new Error('Both obj and pattern must be an object or an array.');
+  }
+  if (!contains(obj, pattern)) {
+    return fail(obj, pattern, message);
+  }
+};
+
+
+module.exports = assertContains;

--- a/generators/app/templates/test/mock/logger.js
+++ b/generators/app/templates/test/mock/logger.js
@@ -1,0 +1,13 @@
+const sinon = require('sinon');
+
+const logger = {
+  child() { return this; },
+  silly : () => sinon.stub(),
+  debug : () => sinon.stub(),
+  verbose: () => sinon.stub(),
+  info: () => sinon.stub(),
+  warn: () => sinon.stub(),
+  error: () => sinon.stub()
+};
+
+module.exports = logger;

--- a/generators/app/templates/test/route.spec.js
+++ b/generators/app/templates/test/route.spec.js
@@ -1,0 +1,183 @@
+/* eslint-disable max-len */
+/* global describe it before beforeEach after */
+
+let request = require('request');
+const assert = require('assert');
+const sinon = require('sinon');
+const assertContains = require('./lib/assert-contains');
+const config = require('../config');
+
+const new<%= className %>1Fixture = require('./fixture/new-<%= name %>-1.js');
+const <%= instanceName %>1Fixture = require('./fixture/<%= name %>-1.js');
+const update<%= className %>1Fixture = require('./fixture/update-<%= name %>-1.js');
+
+config.server.url = 'http://localhost:8050';
+config.mongo.url = 'mongodb://localhost/exact_batchd_test';
+config.logger = {};
+
+const test = require('../');
+const connection = test.database.mongoose.connection;
+
+request = request.defaults({ baseUrl: 'http://localhost:8050' });
+
+describe('<%= className %> Routes', () => {
+  before( (cb) => {
+    sinon.stub(test.tribune, 'register').callsArgWith(2, null);
+    test.start(cb);
+  });
+  beforeEach( (cb) => connection.db.collection('<%= instanceName %>s').remove({}, cb));
+  after( (cb) => {
+    sinon.stub(test.tribune, 'deregister').callsArgWith(0, null);
+    test.stop(() => {
+      test.tribune.register.restore();
+      test.tribune.deregister.restore();
+      cb();
+    });
+  });
+
+  describe('Create <%= className %> Route - POST /', () => {
+    it('creates a <%= instanceName %> document in the database', (cb) => {
+      request.post('<%= instanceName %>', { json: new<%= className %>1Fixture }, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        connection.db.collection('<%= instanceName %>s').find({}).toArray((err, <%= instanceName %>s) => {
+          if (err) { return cb(err); }
+
+          assert.equal(<%= instanceName %>s.length, 1);
+
+          const <%= instanceName %> = <%= instanceName %>s[0];
+          <%= instanceName %>._id = <%= instanceName %>._id.toString();
+          assertContains(<%= instanceName %>, new<%= className %>1Fixture);
+          cb(null);
+        });
+      });
+    });
+
+    it('responds with the newly created account document and a 201 status code', (cb) => {
+      request.post('<%= instanceName %>', { json: new<%= className %>1Fixture }, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        assert.equal(clientRes.statusCode, 201);
+        assertContains(clientRes.body, new<%= className %>1Fixture);
+        cb(null);
+      });
+    });
+
+    it('responds with a 400 error if the body of the request does not align with the schema', (cb) => {
+      request.post('<%= instanceName %>', { json: { foo: 'bar' } }, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        assert.equal(clientRes.statusCode, 400);
+        assert.ok(clientRes.body.match(/ValidationError/));
+        cb(null);
+      });
+    });
+  });
+ 
+  describe('Query <%= className %> Route - GET /', () => {
+    beforeEach( (cb) => connection.db.collection('<%= instanceName %>s').insertOne(<%= instanceName %>1Fixture, cb));
+
+    it('searches for a <%= instanceName %> document by title in the database', (cb) => {
+      request.get('<%= instanceName %>', { json: true }, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        assertContains(clientRes.body, [new<%= className %>1Fixture]);
+
+        cb(null);
+      });
+    });
+  });
+
+  describe('Get <%= className %> Route - GET /:id', () => {
+    beforeEach( (cb) => connection.db.collection('<%= instanceName %>s').insertOne(<%= instanceName %>1Fixture, cb));
+
+    it('retrieves a <%= instanceName %> document in the database', (cb) => {
+      request.get(`<%= instanceName %>/${<%= instanceName %>1Fixture._id.toString()}`, { json: true }, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        assertContains(clientRes.body, new<%= className %>1Fixture);
+
+        cb(null);
+      });
+    });
+  });
+
+  describe('Update <%= className %> by Id Route - PUT /:id', () => {
+    it('updates a document by id and responds with a 204', (cb) => {
+      connection.db.collection('<%= instanceName %>s').insertOne(<%= instanceName %>1Fixture, (err) => {
+        if (err) { return cb(err); }
+
+        request.put(`<%= instanceName %>/${<%= instanceName %>1Fixture._id.toString()}`, { json: update<%= className %>1Fixture }, (err, clientRes) => {
+          if (err) { return cb(err); }
+
+          assert.equal(clientRes.statusCode, 204);
+
+          connection.db.collection('<%= instanceName %>s').findOne({ _id: <%= instanceName %>1Fixture._id }, (err, <%= instanceName %>) => {
+            if (err) { return cb(err); }
+
+            assertContains(<%= instanceName %>, { title: 'Foo' } );
+
+            cb(null);
+          });
+        });
+      });
+    });
+
+    it('responds with a 404 error if a document does not exist with the given id', (cb) => {
+      connection.db.collection('<%= instanceName %>s').insertOne(<%= instanceName %>1Fixture, (err) => {
+        if (err) { return cb(err); }
+
+        request.put('<%= instanceName %>/5d9e362ece1cf00fa05efb96', { json: update<%= className %>1Fixture }, (err, clientRes) => {
+          if (err) { return cb(err); }
+
+          assert.equal(clientRes.statusCode, 404);
+          cb(null);
+        });
+      });
+    });
+  });
+
+  describe('Remove <%= className %> Route - DELETE /:id', () => {
+    beforeEach( (cb) => connection.db.collection('<%= instanceName %>s').insertOne(<%= instanceName %>1Fixture, cb));
+
+    it('removes a <%= instanceName %> document from the database', (cb) => {
+      request.delete(`<%= instanceName %>/${<%= instanceName %>1Fixture._id.toString()}`, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        assert.equal(clientRes.statusCode, 204);
+
+        connection.db.collection('<%= instanceName %>s').findOne({ _id: <%= instanceName %>1Fixture._id }, (err, <%= instanceName %>) => {
+          if (err) { return cb(err); }
+
+          assert.ok(<%= instanceName %>.removedAt instanceof Date);
+          cb(null);
+        });
+      });
+    });
+  });
+
+  describe('Restore <%= className %> Route - POST /restore/:id', () => {
+    beforeEach( (cb) => {
+      connection.db.collection('<%= instanceName %>s').insertOne(
+        Object.assign({}, <%= instanceName %>1Fixture, { removedAt: new Date() }),
+        cb
+      );
+    });
+
+    it('restores a <%= instanceName %> document in the database', (cb) => {
+      request.post(`<%= instanceName %>/restore/${<%= instanceName %>1Fixture._id.toString()}`, (err, clientRes) => {
+        if (err) { return cb(err); }
+
+        assert.equal(clientRes.statusCode, 204);
+
+        connection.db.collection('<%= instanceName %>s').findOne({ _id: <%= instanceName %>1Fixture._id }, (err, <%= instanceName %>) => {
+          if (err) { return cb(err); }
+
+          assert.ok(!<%= instanceName %>.removedAt);
+
+          cb(null);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
1.  Sets baseline code coverage at 67%
2.  Basic fixtures for simple schema
3.  Test support libs
4.  Database/Service/Route Tests
5.  Adds ResourceTests to generator index for installing these.

Verified by installing a service with one resource and running the tests/coverage.

I also noticed a couple other bugs (inability to create more than one resource/router/schema, and camelCase doesn't work when the first letter is capitalized) but I didn't include fixes here.
